### PR TITLE
Add more tests

### DIFF
--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTokenMiddleware(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := GetToken(r.Context(), "")
+		if token != "test-token" {
+			t.Errorf("expected token 'test-token', got '%s'", token)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := TokenMiddleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+
+	middleware.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status code 200, got %d", rec.Code)
+	}
+}
+
+func TestTokenMiddleware_NoToken(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := GetToken(r.Context(), "default-token")
+		if token != "default-token" {
+			t.Errorf("expected token 'default-token', got '%s'", token)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := TokenMiddleware(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	middleware.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status code 200, got %d", rec.Code)
+	}
+}

--- a/pkg/envconfig/envconfig.go
+++ b/pkg/envconfig/envconfig.go
@@ -50,7 +50,7 @@ func Process(spec any, prefix ...string) error {
 
 func processStruct(prefix string, spec reflect.Value) error {
 	types := spec.Type()
-	for n := 0; n < spec.NumField(); n++ {
+	for n := range spec.NumField() {
 		field := spec.Field(n)
 		if !field.CanSet() {
 			continue

--- a/pkg/envconfig/envconfig_test.go
+++ b/pkg/envconfig/envconfig_test.go
@@ -1,0 +1,165 @@
+package envconfig
+
+import (
+	"os"
+	"testing"
+)
+
+type Config struct {
+	Port     int    `envconfig:"PORT" default:"8080"`
+	Host     string `envconfig:"HOST" required:"true"`
+	LogLevel string `envconfig:"LOG_LEVEL" default:"info"`
+}
+
+func TestProcess_WithDefaults(t *testing.T) {
+	os.Clearenv() // Ensure no environment variables are set
+
+	os.Setenv("HOST", "localhost")
+	var cfg Config
+	err := Process(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Port != 8080 {
+		t.Errorf("expected Port to be 8080, got %d", cfg.Port)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("expected LogLevel to be 'info', got %s", cfg.LogLevel)
+	}
+}
+
+func TestProcess_WithEnvironmentVariables(t *testing.T) {
+	os.Setenv("PORT", "9090")
+	os.Setenv("HOST", "localhost")
+	defer os.Clearenv()
+
+	var cfg Config
+	err := Process(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Port != 9090 {
+		t.Errorf("expected Port to be 9090, got %d", cfg.Port)
+	}
+	if cfg.Host != "localhost" {
+		t.Errorf("expected Host to be 'localhost', got %s", cfg.Host)
+	}
+}
+
+func TestProcess_MissingRequiredField(t *testing.T) {
+	os.Clearenv() // Ensure no environment variables are set
+
+	var cfg Config
+	err := Process(&cfg)
+	if err == nil {
+		t.Fatal("expected an error for missing required field, got nil")
+	}
+
+	if err.Error() != "HOST: missing required value" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestProcess_InvalidSpec(t *testing.T) {
+	// Test with a non-pointer value
+	var cfg Config
+	err := Process(cfg)
+	if err == nil || err.Error() != "not a pointer: invalid spec" {
+		t.Errorf("expected 'not a pointer: invalid spec' error, got %v", err)
+	}
+
+	// Test with a non-struct pointer
+	var invalid int
+	err = Process(&invalid)
+	if err == nil || err.Error() != "not a struct: invalid spec" {
+		t.Errorf("expected 'not a struct: invalid spec' error, got %v", err)
+	}
+}
+
+func TestProcess_UnsupportedFieldType(t *testing.T) {
+	type UnsupportedConfig struct {
+		UnsupportedField complex64 `envconfig:"UNSUPPORTED"`
+	}
+
+	os.Clearenv()
+	os.Setenv("UNSUPPORTED", "1+2i")
+
+	var cfg UnsupportedConfig
+	err := Process(&cfg)
+	if err == nil || err.Error() != "UNSUPPORTED: unknown field type" {
+		t.Errorf("expected 'unknown field type' error, got %v", err)
+	}
+}
+
+func TestProcess_DefaultsAndRequired(t *testing.T) {
+	type NestedConfig struct {
+		InnerField string `envconfig:"INNER_FIELD" default:"default-value"`
+	}
+
+	type ConfigWithDefaults struct {
+		Nested NestedConfig `envconfig:"NESTED"`
+	}
+
+	os.Clearenv()
+	var cfg ConfigWithDefaults
+	err := Process(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Nested.InnerField != "default-value" {
+		t.Errorf("expected InnerField to be 'default-value', got %q", cfg.Nested.InnerField)
+	}
+}
+
+func TestProcess_SliceField(t *testing.T) {
+	type SliceConfig struct {
+		Values []string `envconfig:"VALUES"`
+	}
+
+	os.Clearenv()
+	os.Setenv("VALUES", "one,two,three")
+
+	var cfg SliceConfig
+	err := Process(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"one", "two", "three"}
+	if len(cfg.Values) != len(expected) {
+		t.Fatalf("expected %d values, got %d", len(expected), len(cfg.Values))
+	}
+	for i, v := range cfg.Values {
+		if v != expected[i] {
+			t.Errorf("expected value %q, got %q", expected[i], v)
+		}
+	}
+}
+
+func TestProcess_MapField(t *testing.T) {
+	type MapConfig struct {
+		Values map[string]string `envconfig:"VALUES"`
+	}
+
+	os.Clearenv()
+	os.Setenv("VALUES", "key1:value1;key2:value2")
+
+	var cfg MapConfig
+	err := Process(&cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := map[string]string{"key1": "value1", "key2": "value2"}
+	if len(cfg.Values) != len(expected) {
+		t.Fatalf("expected %d map entries, got %d", len(expected), len(cfg.Values))
+	}
+	for k, v := range expected {
+		if cfg.Values[k] != v {
+			t.Errorf("expected key %q to have value %q, got %q", k, v, cfg.Values[k])
+		}
+	}
+}

--- a/pkg/envconfig/setters_test.go
+++ b/pkg/envconfig/setters_test.go
@@ -1,0 +1,87 @@
+package envconfig
+
+import (
+	"encoding/base64"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSetBool(t *testing.T) {
+	var v bool
+	rv := reflect.ValueOf(&v).Elem()
+
+	err := setBool(rv, "true")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != true {
+		t.Errorf("expected true, got %v", v)
+	}
+}
+
+func TestSetDuration(t *testing.T) {
+	var v time.Duration
+	rv := reflect.ValueOf(&v).Elem()
+
+	err := setDuration(rv, "5s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 5*time.Second {
+		t.Errorf("expected 5s, got %v", v)
+	}
+}
+
+func TestSetInt(t *testing.T) {
+	var v int
+	rv := reflect.ValueOf(&v).Elem()
+
+	err := setInt(rv, "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 42 {
+		t.Errorf("expected 42, got %v", v)
+	}
+}
+
+func TestSetUint(t *testing.T) {
+	var v uint
+	rv := reflect.ValueOf(&v).Elem()
+
+	err := setUint(rv, "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 42 {
+		t.Errorf("expected 42, got %v", v)
+	}
+}
+
+func TestSetFloat(t *testing.T) {
+	var v float64
+	rv := reflect.ValueOf(&v).Elem()
+
+	err := setFloat(rv, "3.14")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 3.14 {
+		t.Errorf("expected 3.14, got %v", v)
+	}
+}
+
+func TestSetBytes(t *testing.T) {
+	var v []byte
+	rv := reflect.ValueOf(&v).Elem()
+
+	data := base64.StdEncoding.EncodeToString([]byte("hello"))
+	err := setBytes(rv, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(v) != "hello" {
+		t.Errorf("expected 'hello', got %s", string(v))
+	}
+}

--- a/pkg/expect/expect_test.go
+++ b/pkg/expect/expect_test.go
@@ -1,0 +1,42 @@
+package expect
+
+import (
+	"testing"
+)
+
+func TestValue(t *testing.T) {
+	v := Value(42)
+	if v.exp != 42 {
+		t.Errorf("expected exp to be 42, got %v", v.exp)
+	}
+}
+
+func TestGot(t *testing.T) {
+	v := Value("hello")
+	v.Got("world")
+	if v.got != "world" {
+		t.Errorf("expected got to be 'world', got %v", v.got)
+	}
+}
+
+func TestValidate_Success(t *testing.T) {
+	v := Value(100)
+	v.Got(100)
+	v.Validate(t, "test-value")
+}
+
+func TestValidate_Failure(t *testing.T) {
+	v := Value(100)
+	v.Got(200)
+
+	// Use a subtest to isolate the failure case
+	t.Run("failure case", func(t *testing.T) {
+		// Use a helper to capture test output
+		helper := &testing.T{}
+		v.Validate(helper, "test-value")
+
+		if !helper.Failed() {
+			t.Errorf("expected Validate to fail, but it did not")
+		}
+	})
+}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type mockHTTPClient struct {
+	doFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.doFunc(req)
+}
+
+func TestService_ListVersions(t *testing.T) {
+	mockClient := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/repos/test-org/test-repo/tags" {
+				body := `[
+					{"name": "module/v1.0.0"},
+					{"name": "module/v1.1.0"},
+					{"name": "other/v2.0.0"}
+				]`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+				}, nil
+			}
+			return nil, errors.New("unexpected request")
+		},
+	}
+
+	cfg := Config{
+		OrgMappings: map[string]string{"test-system": "test-org"},
+	}
+	service := New(cfg, mockClient)
+
+	versions, err := service.ListVersions(context.Background(), "test-system", "test-repo", "module")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"v1.0.0", "v1.1.0"}
+	if len(versions) != len(expected) {
+		t.Fatalf("expected %d versions, got %d", len(expected), len(versions))
+	}
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Errorf("expected version %q, got %q", expected[i], v)
+		}
+	}
+}
+
+func TestService_ProxyDownload(t *testing.T) {
+	mockClient := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Path == "/repos/test-org/test-repo/tarball/refs/tags/module/v1.0.0" {
+				var buf bytes.Buffer
+				gz := gzip.NewWriter(&buf)
+				tw := tar.NewWriter(gz)
+
+				// Add a fake file to the tar archive with the expected structure
+				header := &tar.Header{
+					Name: "test-org-test-repo-branch/module/testfile.txt",
+					Mode: 0600,
+					Size: int64(len("fake tarball content")),
+				}
+				if err := tw.WriteHeader(header); err != nil {
+					return nil, err
+				}
+
+				if _, err := tw.Write([]byte("fake tarball content")); err != nil {
+					return nil, err
+				}
+
+				// Close the tar and gzip writers
+				_ = tw.Close()
+				_ = gz.Close()
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(&buf),
+				}, nil
+
+			}
+			return nil, errors.New("unexpected request")
+		},
+	}
+
+	cfg := Config{
+		OrgMappings: map[string]string{"test-system": "test-org"},
+	}
+	service := New(cfg, mockClient)
+
+	var buf bytes.Buffer
+	err := service.ProxyDownload(context.Background(), "test-system", "test-repo", "module", "v1.0.0", &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Decompress the output to validate its content
+	gz, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("failed to create gzip reader: %v", err)
+	}
+	defer gz.Close()
+
+	var tarBuf bytes.Buffer
+	if _, err := io.Copy(&tarBuf, gz); err != nil {
+		t.Fatalf("failed to decompress gzip: %v", err)
+	}
+
+	expectedContent := "fake tarball content"
+	if !bytes.Contains(tarBuf.Bytes(), []byte(expectedContent)) {
+		t.Errorf("expected tarball to contain %q, but it was %q", expectedContent, tarBuf.Bytes())
+	}
+}

--- a/pkg/mcache/mcache_test.go
+++ b/pkg/mcache/mcache_test.go
@@ -1,0 +1,90 @@
+package mcache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCache_SetAndGet(t *testing.T) {
+	cache := New[string, string](time.Minute)
+
+	cache.Set("key1", "value1")
+	value, ok := cache.Get("key1")
+	if !ok || value != "value1" {
+		t.Errorf("expected value1, got %v", value)
+	}
+}
+
+func TestCache_GetExpired(t *testing.T) {
+	cache := New[string, string](time.Millisecond)
+
+	cache.Set("key1", "value1")
+	time.Sleep(2 * time.Millisecond)
+	_, ok := cache.Get("key1")
+	if ok {
+		t.Error("expected key1 to be expired")
+	}
+}
+
+func TestCache_Delete(t *testing.T) {
+	cache := New[string, string](time.Minute)
+
+	cache.Set("key1", "value1")
+	deleted := cache.Delete("key1")
+	if !deleted {
+		t.Error("expected key1 to be deleted")
+	}
+
+	_, ok := cache.Get("key1")
+	if ok {
+		t.Error("expected key1 to be absent")
+	}
+}
+
+func TestCache_Count(t *testing.T) {
+	cache := New[string, string](time.Minute)
+
+	cache.Set("key1", "value1")
+	cache.Set("key2", "value2")
+	if count := cache.Count(); count != 2 {
+		t.Errorf("expected count 2, got %d", count)
+	}
+}
+
+func TestCache_Cleanup(t *testing.T) {
+	cache := New[string, string](time.Millisecond)
+
+	cache.Set("key1", "value1")
+	cache.Set("key2", "value2", 2*time.Millisecond)
+	time.Sleep(3 * time.Millisecond)
+
+	cleaned := cache.Cleanup()
+	if cleaned != 2 {
+		t.Errorf("expected 2 items cleaned, got %d", cleaned)
+	}
+}
+
+func TestCache_Flush(t *testing.T) {
+	cache := New[string, string](time.Minute)
+
+	cache.Set("key1", "value1")
+	cache.Set("key2", "value2")
+	cache.Flush()
+
+	if count := cache.Count(); count != 0 {
+		t.Errorf("expected count 0 after flush, got %d", count)
+	}
+}
+
+func TestStartCleanupLoop(t *testing.T) {
+	cache := New[string, string](time.Millisecond)
+
+	cache.Set("key1", "value1")
+	stop := StartCleanupLoop(cache, time.Millisecond)
+	time.Sleep(3 * time.Millisecond)
+	stop()
+
+	if count := cache.Count(); count != 0 {
+		t.Errorf("expected count 0 after cleanup loop, got %d", count)
+	}
+}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,0 +1,64 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRouter_Get(t *testing.T) {
+	r := New()
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test handler"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	if rec.Body.String() != "test handler" {
+		t.Fatalf("expected body %q, got %q", "test handler", rec.Body.String())
+	}
+}
+
+func TestRouter_Parameter(t *testing.T) {
+	r := New()
+	r.Get("/user/:id", func(w http.ResponseWriter, r *http.Request) {
+		id := GetParameter(r.Context(), "id")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("user id: " + id))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/user/123", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+
+	expectedBody := "user id: 123"
+	if rec.Body.String() != expectedBody {
+		t.Fatalf("expected body %q, got %q", expectedBody, rec.Body.String())
+	}
+}
+
+func TestRouter_NotFound(t *testing.T) {
+	r := New()
+
+	req := httptest.NewRequest(http.MethodGet, "/nonexistent", nil)
+	rec := httptest.NewRecorder()
+
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type mockLogger struct {
+	errors []string
+	infos  []string
+}
+
+func (m *mockLogger) Error(msg string, args ...any) {
+	m.errors = append(m.errors, msg)
+}
+
+func (m *mockLogger) Info(msg string, args ...any) {
+	m.infos = append(m.infos, msg)
+}
+
+func TestStartServer(t *testing.T) {
+	cfg := Config{
+		Host:    "127.0.0.1",
+		Port:    8081,
+		Timeout: Config{}.Timeout,
+	}
+
+	logger := &mockLogger{}
+	handler := http.NewServeMux()
+	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	listening := make(chan net.Addr, 1)
+	go func() {
+		if err := Start(cfg, logger, handler, listening); err != nil {
+			t.Errorf("server failed to start: %v", err)
+		}
+	}()
+
+	select {
+	case addr := <-listening:
+		if addr == nil {
+			t.Error("server did not start listening")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for server to start")
+	}
+}

--- a/services/modules/cache_test.go
+++ b/services/modules/cache_test.go
@@ -1,0 +1,116 @@
+package modules
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+type mockKeyValueStore struct {
+	data map[string][]string
+}
+
+func (m *mockKeyValueStore) Get(key string) ([]string, bool) {
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockKeyValueStore) Set(key string, value []string, d ...time.Duration) {
+	m.data[key] = value
+}
+
+type mockFileStorage struct {
+	files map[string][]byte
+}
+
+func (m *mockFileStorage) Open(filename string) (io.ReadCloser, error) {
+	data, ok := m.files[filename]
+	if !ok {
+		return nil, errors.New("file not found")
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (m *mockFileStorage) Create(filename string) (io.WriteCloser, error) {
+	var buf bytes.Buffer
+	m.files[filename] = buf.Bytes()
+	return nopWriteCloser{&buf, func() { m.files[filename] = buf.Bytes() }}, nil
+}
+
+type nopWriteCloser struct {
+	*bytes.Buffer
+	closeFunc func()
+}
+
+func (n nopWriteCloser) Close() error {
+	n.closeFunc()
+	return nil
+}
+
+type mockCacheRepository struct {
+	versions map[string][]string
+}
+
+func (m *mockCacheRepository) ListVersions(ctx context.Context, owner, repo, module string) ([]string, error) {
+	key := owner + "/" + repo + "/" + module
+	v, ok := m.versions[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+
+func (m *mockCacheRepository) ProxyDownload(ctx context.Context, owner, repo, module, version string, w io.Writer) error {
+	_, err := w.Write([]byte("fake tarball content"))
+	return err
+}
+
+type mockLogger struct{}
+
+func (m *mockLogger) Error(msg string, keysAndValues ...any) {}
+func (m *mockLogger) Info(msg string, keysAndValues ...any)  {}
+
+func TestCache_ListVersions(t *testing.T) {
+	store := &mockKeyValueStore{data: make(map[string][]string)}
+	repo := &mockCacheRepository{versions: map[string][]string{
+		"owner/repo/module": {"v1.0.0", "v1.1.0"},
+	}}
+	cache := NewCache(repo, store, nil, nil)
+
+	versions, err := cache.ListVersions(context.Background(), "owner", "repo", "module")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []string{"v1.0.0", "v1.1.0"}
+	if len(versions) != len(expected) {
+		t.Fatalf("expected %d versions, got %d", len(expected), len(versions))
+	}
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Errorf("expected version %q, got %q", expected[i], v)
+		}
+	}
+}
+
+func TestCache_ProxyDownload(t *testing.T) {
+	store := &mockKeyValueStore{data: make(map[string][]string)}
+	files := &mockFileStorage{files: make(map[string][]byte)}
+	repo := &mockCacheRepository{}
+	logger := &mockLogger{}
+	cache := NewCache(repo, store, files, logger)
+
+	var buf bytes.Buffer
+	err := cache.ProxyDownload(context.Background(), "owner", "repo", "module", "v1.0.0", &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedContent := "fake tarball content"
+	if buf.String() != expectedContent {
+		t.Errorf("expected content %q, got %q", expectedContent, buf.String())
+	}
+}


### PR DESCRIPTION
Add code coverage for all modules.

```
❯ task test
task: [test] go test -race -cover ./...
        github.com/reMarkable/orbit/cmd/server          coverage: 0.0% of statements
ok      github.com/reMarkable/orbit/pkg/auth    (cached)        coverage: 100.0% of statements
ok      github.com/reMarkable/orbit/pkg/envconfig       (cached)        coverage: 73.2% of statements
ok      github.com/reMarkable/orbit/pkg/expect  (cached)        coverage: 100.0% of statements
ok      github.com/reMarkable/orbit/pkg/github  (cached)        coverage: 68.5% of statements
ok      github.com/reMarkable/orbit/pkg/mcache  (cached)        coverage: 96.5% of statements
ok      github.com/reMarkable/orbit/pkg/router  (cached)        coverage: 82.8% of statements
ok      github.com/reMarkable/orbit/pkg/server  (cached)        coverage: 48.8% of statements
ok      github.com/reMarkable/orbit/services/modules    (cached)        coverage: 31.0% of statements
```