### PR TITLE
fix!: Keep auth semantics when cache is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env*
+*.pem
+.terraform/
+tmp/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ release process.
 | -------------------------- | -------- | ------- | -------- | -------------------------------------- |
 | MODULES_PROXY_SECRET       | []byte   |         | Yes      | Secret key for proxy token encryption. |
 | CACHE_ENABLED              | bool     |         | No       | Enable or disable caching.             |
+| CACHE_AUTH_DISABLED        | bool     |         | No       | Disable auth for cached requests.      |
 | CACHE_PATH                 | string   | /tmp    | No       | Path to store cache files.             |
 | CACHE_EXPIRATION           | duration | 10s     | No       | Cache expiration duration.             |
 | GITHUB_REPOSITORIES        | map      |         | No       | Allowed repositories (per org).        |
@@ -40,7 +41,7 @@ release process.
 - Some variables (like maps) may require specific formatting (e.g., JSON or comma-separated values).
 - MODULES_PROXY_SECRET must be a base64-encoded 16, 24 or 32-byte key for AES encryption.
 
-# Deployment
+## Deployment
 
 Orbit can easily be deployed using Docker, or by just running the binary
 provided in the release. If you want to deploy using Kubernetes, we're providing

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,9 +21,10 @@ import (
 
 type config struct {
 	Cache struct {
-		Enabled    bool          `envconfig:"ENABLED"`
-		Path       string        `envconfig:"PATH" default:"/tmp"`
-		Expiration time.Duration `envconfig:"EXPIRATION" default:"10s"`
+		Enabled      bool          `envconfig:"ENABLED"`
+		AuthDisabled bool          `envconfig:"AUTH_DISABLED"`
+		Path         string        `envconfig:"PATH" default:"/tmp"`
+		Expiration   time.Duration `envconfig:"EXPIRATION" default:"10s"`
 	} `envconfig:"CACHE_"`
 	Github  github.Config  `envconfig:"GITHUB_"`
 	Modules modules.Config `envconfig:"MODULES_"`
@@ -42,12 +43,16 @@ func main() {
 	})
 
 	if cfg.Cache.Enabled {
-		log.Info("enabling cache", "path", cfg.Cache.Path, "expiration", cfg.Cache.Expiration)
+		log.Info("enabling cache", "path", cfg.Cache.Path, "expiration", cfg.Cache.Expiration, "authDisabled", cfg.Cache.AuthDisabled)
+		if cfg.Cache.AuthDisabled {
+			log.Warn("auth is disabled for cached request. This is dangerous when used with private repos, or in environments with no other access control mechanisms in place")
+		}
 		repo = modules.NewCache(
 			repo,
 			mcache.New[string, []string](cfg.Cache.Expiration),
 			modules.StoreInPath(cfg.Cache.Path),
 			log,
+			cfg.Cache.AuthDisabled,
 		)
 	}
 

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -62,7 +62,7 @@ func (s *Service) ListVersions(ctx context.Context, system, repo, module string)
 	)
 	for {
 		uri := fmt.Sprintf("repos/%s/%s/tags?per_page=%d&page=%d", owner, repo, tagsPerPage, page)
-		res, err := s.makeRequest(ctx, uri)
+		res, err := s.makeRequest(ctx, http.MethodGet, uri)
 		if err != nil {
 			return nil, err
 		}
@@ -101,7 +101,7 @@ func (s *Service) ProxyDownload(ctx context.Context, system, repo, module, versi
 	}
 
 	uri := fmt.Sprintf("repos/%s/%s/tarball/refs/tags/%s/%s", owner, repo, module, version)
-	body, err := s.makeRequest(ctx, uri)
+	body, err := s.makeRequest(ctx, http.MethodGet, uri)
 	if err != nil {
 		return err
 	}
@@ -143,9 +143,29 @@ func (s *Service) ProxyDownload(ctx context.Context, system, repo, module, versi
 	return nil
 }
 
-func (s *Service) makeRequest(ctx context.Context, uri string) (io.ReadCloser, error) {
+func (s *Service) RepoHead(ctx context.Context, system, repo string) error {
+	owner := s.mapOrg(system)
+	if err := s.validRepo(owner, repo); err != nil {
+		return err
+	}
+
+	uri := fmt.Sprintf("repos/%s/%s", owner, repo)
+	res, err := s.makeRequest(ctx, http.MethodHead, uri)
+	if err != nil {
+		return err
+	}
+
+	cerr := res.Close()
+	if cerr != nil {
+		return fmt.Errorf("closing response: %w", cerr)
+	}
+
+	return nil
+}
+
+func (s *Service) makeRequest(ctx context.Context, method, uri string) (io.ReadCloser, error) {
 	url := fmt.Sprintf("https://api.github.com/%s", uri)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("new request: %w", err)
 	}

--- a/services/modules/cache.go
+++ b/services/modules/cache.go
@@ -23,20 +23,36 @@ type FileStorage interface {
 	Create(filename string) (io.WriteCloser, error)
 }
 
-func NewCache(r Repository, s KeyValueStore, f FileStorage, l Logger) *Cache {
-	return &Cache{f, l, r, s}
+func NewCache(r Repository, s KeyValueStore, f FileStorage, l Logger, authDisabled bool) *Cache {
+	return &Cache{f, l, r, s, authDisabled}
 }
 
 type Cache struct {
-	files FileStorage
-	log   Logger
-	repo  Repository
-	store KeyValueStore
+	files        FileStorage
+	log          Logger
+	repo         Repository
+	store        KeyValueStore
+	authDisabled bool
+}
+
+// RepoHead is used to check if we can access the repository in a cheap way.
+func (c *Cache) RepoHead(ctx context.Context, owner, repo string) error {
+	if c.authDisabled {
+		return nil
+	}
+
+	return c.repo.RepoHead(ctx, owner, repo)
 }
 
 func (c *Cache) ListVersions(ctx context.Context, owner, repo, module string) ([]string, error) {
 	key := fmt.Sprintf("%s-%s-%s", owner, repo, module)
 	if v, ok := c.store.Get(key); ok {
+
+		err := c.RepoHead(ctx, owner, repo)
+		if err != nil {
+			return nil, err
+		}
+
 		return v, nil
 	}
 
@@ -55,12 +71,25 @@ func (c *Cache) ProxyDownload(ctx context.Context, owner, repo, module, version 
 		// If we just fail to open the cached file, we'll just log the error and
 		// then re-download it from the repository as usual.
 		c.log.Error("failed to open cached file", "err", err)
-	} else if _, err := io.Copy(w, r); err != nil {
-		// Since the copy operation failed, we may have partially copied the
-		// file, so there's no point in trying to read the original.
-		c.log.Error("failed to copy cached file", "err", err)
-		return err
 	} else {
+		defer func() {
+			if err := r.Close(); err != nil {
+				slog.Error("failed to close cached file", "err", err)
+			}
+		}()
+
+		// Verify repository access before writing any cached content to the
+		// response, otherwise we may leak the cached file to callers who do
+		// not have access to the repository.
+		if err := c.RepoHead(ctx, owner, repo); err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(w, r); err != nil {
+			c.log.Error("failed to copy cached file", "err", err)
+			return err
+		}
+
 		// At this point we have copied the cached file, so we are done.
 		return nil
 	}

--- a/services/modules/cache_test.go
+++ b/services/modules/cache_test.go
@@ -51,7 +51,9 @@ func (n nopWriteCloser) Close() error {
 }
 
 type mockCacheRepository struct {
-	versions map[string][]string
+	versions    map[string][]string
+	repoHeadSet bool
+	repoHeadErr error
 }
 
 func (m *mockCacheRepository) ListVersions(ctx context.Context, owner, repo, module string) ([]string, error) {
@@ -68,6 +70,19 @@ func (m *mockCacheRepository) ProxyDownload(ctx context.Context, owner, repo, mo
 	return err
 }
 
+func (m *mockCacheRepository) RepoHead(ctx context.Context, owner, repo string) error {
+	if m.repoHeadSet {
+		return m.repoHeadErr
+	}
+	prefix := owner + "/" + repo + "/"
+	for k := range m.versions {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
 type mockLogger struct{}
 
 func (m *mockLogger) Error(msg string, keysAndValues ...any) {}
@@ -78,7 +93,7 @@ func TestCache_ListVersions(t *testing.T) {
 	repo := &mockCacheRepository{versions: map[string][]string{
 		"owner/repo/module": {"v1.0.0", "v1.1.0"},
 	}}
-	cache := NewCache(repo, store, nil, nil)
+	cache := NewCache(repo, store, nil, nil, false)
 
 	versions, err := cache.ListVersions(context.Background(), "owner", "repo", "module")
 	if err != nil {
@@ -101,7 +116,7 @@ func TestCache_ProxyDownload(t *testing.T) {
 	files := &mockFileStorage{files: make(map[string][]byte)}
 	repo := &mockCacheRepository{}
 	logger := &mockLogger{}
-	cache := NewCache(repo, store, files, logger)
+	cache := NewCache(repo, store, files, logger, false)
 
 	var buf bytes.Buffer
 	err := cache.ProxyDownload(context.Background(), "owner", "repo", "module", "v1.0.0", &buf)
@@ -112,5 +127,92 @@ func TestCache_ProxyDownload(t *testing.T) {
 	expectedContent := "fake tarball content"
 	if buf.String() != expectedContent {
 		t.Errorf("expected content %q, got %q", expectedContent, buf.String())
+	}
+}
+
+func TestCache_ListVersions_CacheHit(t *testing.T) {
+	wantErr := errors.New("forbidden")
+	tests := map[string]struct {
+		repoHeadErr  error
+		authDisabled bool
+		wantErr      error
+		wantVersions []string
+	}{
+		"RepoHeadSucceeds": {
+			repoHeadErr:  nil,
+			wantVersions: []string{"v1.0.0", "v1.1.0"},
+		},
+		"RepoHeadFails": {
+			repoHeadErr: wantErr,
+			wantErr:     wantErr,
+		},
+		"AuthDisabled": {
+			// RepoHead would fail, but auth is disabled so it must not be consulted.
+			repoHeadErr:  wantErr,
+			authDisabled: true,
+			wantVersions: []string{"v1.0.0", "v1.1.0"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := &mockKeyValueStore{data: map[string][]string{
+				"owner-repo-module": {"v1.0.0", "v1.1.0"},
+			}}
+			repo := &mockCacheRepository{repoHeadSet: true, repoHeadErr: tc.repoHeadErr}
+			cache := NewCache(repo, store, nil, &mockLogger{}, tc.authDisabled)
+
+			versions, err := cache.ListVersions(context.Background(), "owner", "repo", "module")
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+			if len(versions) != len(tc.wantVersions) {
+				t.Fatalf("expected %d versions, got %d", len(tc.wantVersions), len(versions))
+			}
+			for i, v := range versions {
+				if v != tc.wantVersions[i] {
+					t.Errorf("expected version %q, got %q", tc.wantVersions[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestCache_ProxyDownload_CacheHit(t *testing.T) {
+	const cached = "cached tarball content"
+	wantErr := errors.New("forbidden")
+	tests := map[string]struct {
+		repoHeadErr error
+		wantErr     error
+		wantContent string
+	}{
+		"RepoHeadSucceeds": {
+			repoHeadErr: nil,
+			wantContent: cached,
+		},
+		"RepoHeadFails": {
+			repoHeadErr: wantErr,
+			wantErr:     wantErr,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := &mockKeyValueStore{data: make(map[string][]string)}
+			files := &mockFileStorage{files: map[string][]byte{
+				"owner-repo-module-v1.0.0.tar.gz": []byte(cached),
+			}}
+			repo := &mockCacheRepository{repoHeadSet: true, repoHeadErr: tc.repoHeadErr}
+			cache := NewCache(repo, store, files, &mockLogger{}, false)
+
+			var buf bytes.Buffer
+			err := cache.ProxyDownload(context.Background(), "owner", "repo", "module", "v1.0.0", &buf)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+			if buf.String() != tc.wantContent {
+				t.Errorf("expected content %q, got %q", tc.wantContent, buf.String())
+			}
+		})
 	}
 }

--- a/services/modules/http.go
+++ b/services/modules/http.go
@@ -45,6 +45,7 @@ type Logger interface {
 type Repository interface {
 	ListVersions(ctx context.Context, owner, repo, module string) ([]string, error)
 	ProxyDownload(ctx context.Context, owner, repo, module, version string, w io.Writer) error
+	RepoHead(ctx context.Context, owner, repo string) error
 }
 
 func NewHTTP(cfg Config, log Logger, r Repository, mh *MetricsHandler) (*Handler, error) {

--- a/services/modules/http_test.go
+++ b/services/modules/http_test.go
@@ -143,6 +143,12 @@ func (m *mockRepository) ProxyDownload(ctx context.Context, owner, repo, module,
 	return m.err
 }
 
+func (m *mockRepository) RepoHead(ctx context.Context, owner, repo string) error {
+	m.owner.Got(owner)
+	m.repo.Got(repo)
+	return m.err
+}
+
 func (m *mockRepository) validate(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
Add a fairly cheap HTTP HEAD request for each cached request, piggybacking on the GitHub access controls for authorizing a users permission to repo read contents.

To revert to the old behaviour you can set `CACHE_AUTH_DISABLED=true`